### PR TITLE
Set close-on-exec and similar by default.

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1018,6 +1018,12 @@ impl Socket {
     }
 }
 
+impl Drop for Socket {
+    fn drop(&mut self) {
+        close(self.fd);
+    }
+}
+
 impl Read for Socket {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         <&Socket>::read(&mut &*self, buf)
@@ -1085,7 +1091,7 @@ impl IntoRawFd for Socket {
 
 impl FromRawFd for Socket {
     unsafe fn from_raw_fd(fd: c_int) -> Socket {
-        Socket { fd: fd }
+        Socket { fd }
     }
 }
 
@@ -1105,9 +1111,7 @@ impl IntoRawFd for crate::Socket {
 
 impl FromRawFd for crate::Socket {
     unsafe fn from_raw_fd(fd: c_int) -> crate::Socket {
-        crate::Socket {
-            inner: Socket::from_raw_fd(fd).inner(),
-        }
+        crate::Socket { inner: fd }
     }
 }
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -167,6 +167,18 @@ impl Type {
         )
     ))]
     pub const fn cloexec(self) -> Type {
+        self._cloexec()
+    }
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    pub(crate) const fn _cloexec(self) -> Type {
         Type(self.0 | libc::SOCK_CLOEXEC)
     }
 }
@@ -396,24 +408,32 @@ impl crate::Socket {
         )
     ))]
     pub fn accept4(&self, flags: c_int) -> io::Result<(crate::Socket, SockAddr)> {
+        self._accept4(flags)
+    }
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    pub(crate) fn _accept4(&self, flags: c_int) -> io::Result<(crate::Socket, SockAddr)> {
+        // Safety: zeroed `sockaddr_storage` is valid.
         let mut storage: libc::sockaddr_storage = unsafe { mem::zeroed() };
         let mut len = mem::size_of_val(&storage) as socklen_t;
-
-        let res = syscall!(accept4(
+        syscall!(accept4(
             self.inner,
             &mut storage as *mut _ as *mut _,
             &mut len,
-            flags,
-        ));
-        match res {
-            Ok(inner) => {
-                let socket = crate::Socket { inner };
-                let addr =
-                    unsafe { SockAddr::from_raw_parts(&storage as *const _ as *const _, len) };
-                Ok((socket, addr))
-            }
-            Err(e) => Err(e),
-        }
+            flags
+        ))
+        .map(|inner| {
+            let addr = unsafe { SockAddr::from_raw_parts(&storage as *const _ as *const _, len) };
+            (crate::Socket { inner }, addr)
+        })
     }
 
     /// Sets `CLOEXEC` on the socket.
@@ -421,7 +441,12 @@ impl crate::Socket {
     /// # Notes
     ///
     /// On supported platforms you can use [`Protocol::cloexec`].
+    #[cfg(feature = "all")]
     pub fn set_cloexec(&self, close_on_exec: bool) -> io::Result<()> {
+        self._set_cloexec(close_on_exec)
+    }
+
+    pub(crate) fn _set_cloexec(&self, close_on_exec: bool) -> io::Result<()> {
         if close_on_exec {
             fcntl_add(self.inner, libc::F_GETFD, libc::F_SETFD, libc::FD_CLOEXEC)
         } else {
@@ -436,12 +461,17 @@ impl crate::Socket {
     /// Only supported on Apple platforms (`target_vendor = "apple"`).
     #[cfg(all(feature = "all", target_vendor = "apple"))]
     pub fn set_nosigpipe(&self, nosigpipe: bool) -> io::Result<()> {
+        self._set_nosigpipe(nosigpipe)
+    }
+
+    #[cfg(target_vendor = "apple")]
+    pub(crate) fn _set_nosigpipe(&self, nosigpipe: bool) -> io::Result<()> {
         unsafe {
-            setsockopt::<c_int>(
+            setsockopt(
                 self.inner,
                 libc::SOL_SOCKET,
                 libc::SO_NOSIGPIPE,
-                nosigpipe as _,
+                nosigpipe as c_int,
             )
         }
     }
@@ -490,7 +520,7 @@ unsafe fn getsockopt<T>(fd: SysSocket, opt: c_int, val: c_int) -> io::Result<T> 
 }
 
 /// Caller must ensure `T` is the correct type for `opt` and `val`.
-#[cfg(all(feature = "all", target_vendor = "apple"))]
+#[cfg(target_vendor = "apple")]
 unsafe fn setsockopt<T>(fd: SysSocket, opt: c_int, val: c_int, payload: T) -> io::Result<()> {
     let payload = &payload as *const T as *const c_void;
     syscall!(setsockopt(
@@ -502,15 +532,6 @@ unsafe fn setsockopt<T>(fd: SysSocket, opt: c_int, val: c_int, payload: T) -> io
     ))
     .map(|_| ())
 }
-
-/*
-            setsockopt::<c_int>(
-                self.inner,
-                libc::SOL_SOCKET,
-                libc::SO_NOSIGPIPE,
-                nosigpipe as _,
-            )
-*/
 
 #[repr(transparent)] // Required during rewriting.
 pub struct Socket {

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -882,6 +882,12 @@ impl Socket {
     }
 }
 
+impl Drop for Socket {
+    fn drop(&mut self) {
+        close(self.socket);
+    }
+}
+
 impl Read for Socket {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         <&Socket>::read(&mut &*self, buf)
@@ -966,9 +972,7 @@ impl IntoRawSocket for crate::Socket {
 
 impl FromRawSocket for crate::Socket {
     unsafe fn from_raw_socket(socket: RawSocket) -> crate::Socket {
-        crate::Socket {
-            inner: Socket::from_raw_socket(socket).inner(),
-        }
+        crate::Socket { inner: socket }
     }
 }
 

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -93,6 +93,10 @@ impl Type {
     /// Set `WSA_FLAG_NO_HANDLE_INHERIT` on the socket.
     #[cfg(feature = "all")]
     pub const fn no_inherit(self) -> Type {
+        self._no_inherit()
+    }
+
+    pub(crate) const fn _no_inherit(self) -> Type {
         Type(self.0 | Type::NO_INHERIT)
     }
 }
@@ -297,7 +301,12 @@ fn ioctlsocket(socket: SysSocket, cmd: c_long, payload: &mut u_long) -> io::Resu
 /// Windows only API.
 impl crate::Socket {
     /// Sets `HANDLE_FLAG_INHERIT` to zero using `SetHandleInformation`.
+    #[cfg(feature = "all")]
     pub fn set_no_inherit(&self, no_inherit: bool) -> io::Result<()> {
+        self._set_no_inherit(no_inherit)
+    }
+
+    pub(crate) fn _set_no_inherit(&self, no_inherit: bool) -> io::Result<()> {
         // NOTE: can't use `syscall!` because it expects the function in the
         // `sock::` path.
         let res = unsafe {
@@ -972,7 +981,9 @@ impl IntoRawSocket for crate::Socket {
 
 impl FromRawSocket for crate::Socket {
     unsafe fn from_raw_socket(socket: RawSocket) -> crate::Socket {
-        crate::Socket { inner: socket }
+        crate::Socket {
+            inner: socket as SysSocket,
+        }
     }
 }
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -61,17 +61,17 @@ pub fn assert_nonblocking<S>(_: &S, _: bool) {
     // No way to get this information...
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "all"))]
 #[test]
 fn set_cloexec() {
     let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
-    assert_close_on_exec(&socket, false);
-
-    socket.set_cloexec(true).unwrap();
     assert_close_on_exec(&socket, true);
 
     socket.set_cloexec(false).unwrap();
     assert_close_on_exec(&socket, false);
+
+    socket.set_cloexec(true).unwrap();
+    assert_close_on_exec(&socket, true);
 }
 
 #[cfg(all(
@@ -103,17 +103,17 @@ where
     assert_eq!(flags & libc::FD_CLOEXEC != 0, want, "CLOEXEC option");
 }
 
-#[cfg(windows)]
+#[cfg(all(windows, feature = "all"))]
 #[test]
 fn set_no_inherit() {
     let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
-    assert_flag_no_inherit(&socket, false);
-
-    socket.set_no_inherit(true).unwrap();
     assert_flag_no_inherit(&socket, true);
 
     socket.set_no_inherit(false).unwrap();
     assert_flag_no_inherit(&socket, false);
+
+    socket.set_no_inherit(true).unwrap();
+    assert_flag_no_inherit(&socket, true);
 }
 
 #[cfg(all(feature = "all", windows))]
@@ -147,13 +147,13 @@ where
 #[test]
 fn set_nosigpipe() {
     let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
-    assert_flag_no_sigpipe(&socket, false);
-
-    socket.set_nosigpipe(true).unwrap();
     assert_flag_no_sigpipe(&socket, true);
 
     socket.set_nosigpipe(false).unwrap();
     assert_flag_no_sigpipe(&socket, false);
+
+    socket.set_nosigpipe(true).unwrap();
+    assert_flag_no_sigpipe(&socket, true);
 }
 
 /// Assert that `SO_NOSIGPIPE` is set on `socket`.


### PR DESCRIPTION
This is my proposal for #111: the default behavior is to enable close-on-exec and `SOCK_NOSIGPIPE` on the relevant platforms, but there are `*_raw` functions that really only wrap a single syscall.