### PR TITLE
 Don't assume memory layout of std::net::SocketAddr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ features = ["handleapi", "ws2def", "ws2ipdef", "ws2tcpip", "minwindef"]
 
 [target."cfg(any(unix, target_os = \"redox\"))".dependencies]
 cfg-if = "0.1.6"
-libc = "0.2.66"
+libc = { version = "0.2.66", features = ["align"] }
 
 [target."cfg(target_os = \"redox\")".dependencies]
 redox_syscall = "0.1.38"

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -212,9 +212,7 @@ impl From<SocketAddrV4> for SockAddr {
             in_addr { S_un: s_un }
         };
 
-        let mut storage = MaybeUninit::<sockaddr_storage>::zeroed();
-        let sockaddr_in = unsafe { &mut *(storage.as_mut_ptr() as *mut sockaddr_in) };
-        *sockaddr_in = sockaddr_in {
+        let sockaddr_in = sockaddr_in {
             sin_family: AF_INET as sa_family_t,
             sin_port: addr.port().to_be(),
             sin_addr,
@@ -229,6 +227,9 @@ impl From<SocketAddrV4> for SockAddr {
             ))]
             sin_len: 0,
         };
+        let mut storage = MaybeUninit::<sockaddr_storage>::zeroed();
+        // Safety: A `sockaddr_in` is memory compatible with a `sockaddr_storage`
+        unsafe { (storage.as_mut_ptr() as *mut sockaddr_in).write(sockaddr_in) };
         SockAddr {
             storage: unsafe { storage.assume_init() },
             len: mem::size_of::<sockaddr_in>() as socklen_t,
@@ -255,9 +256,7 @@ impl From<SocketAddrV6> for SockAddr {
             u
         };
 
-        let mut storage = MaybeUninit::<sockaddr_storage>::zeroed();
-        let sockaddr_in6 = unsafe { &mut *(storage.as_mut_ptr() as *mut sockaddr_in6) };
-        *sockaddr_in6 = sockaddr_in6 {
+        let sockaddr_in6 = sockaddr_in6 {
             sin6_family: AF_INET6 as sa_family_t,
             sin6_port: addr.port().to_be(),
             sin6_addr,
@@ -278,6 +277,9 @@ impl From<SocketAddrV6> for SockAddr {
             #[cfg(any(target_os = "solaris", target_os = "illumos"))]
             __sin6_src_id: 0,
         };
+        let mut storage = MaybeUninit::<sockaddr_storage>::zeroed();
+        // Safety: A `sockaddr_in6` is memory compatible with a `sockaddr_storage`
+        unsafe { (storage.as_mut_ptr() as *mut sockaddr_in6).write(sockaddr_in6) };
         SockAddr {
             storage: unsafe { storage.assume_init() },
             len: mem::size_of::<sockaddr_in6>() as socklen_t,

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -146,6 +146,7 @@ impl SockAddr {
     /// or `AF_INET6` family, otherwise returns `None`.
     pub fn as_std(&self) -> Option<SocketAddr> {
         if self.storage.ss_family == AF_INET as sa_family_t {
+            // Safety: if the ss_family field is AF_INET then storage must be a sockaddr_in.
             let addr = unsafe { &*(&self.storage as *const _ as *const sockaddr_in) };
 
             #[cfg(unix)]
@@ -158,6 +159,7 @@ impl SockAddr {
             let port = u16::from_be(addr.sin_port);
             Some(SocketAddr::V4(SocketAddrV4::new(ip, port)))
         } else if self.storage.ss_family == AF_INET6 as sa_family_t {
+            // Safety: if the ss_family field is AF_INET6 then storage must be a sockaddr_in6.
             let addr = unsafe { &*(&self.storage as *const _ as *const sockaddr_in6) };
 
             #[cfg(unix)]

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -183,14 +183,12 @@ impl SockAddr {
 
 impl From<SocketAddrV4> for SockAddr {
     fn from(addr: SocketAddrV4) -> SockAddr {
-        let sin_addr = in_addr {
-            s_addr: u32::from_ne_bytes(addr.ip().octets()),
-        };
-
         let sockaddr_in = sockaddr_in {
             sin_family: AF_INET as sa_family_t,
             sin_port: addr.port().to_be(),
-            sin_addr,
+            sin_addr: in_addr {
+                s_addr: u32::from_ne_bytes(addr.ip().octets()),
+            },
             ..unsafe { mem::zeroed() }
         };
 

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -57,7 +57,7 @@ impl SockAddr {
         SockAddr {
             // This is safe as we written the address to `storage` above.
             storage: storage.assume_init(),
-            len: len,
+            len,
         }
     }
 

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -47,10 +47,10 @@ impl fmt::Debug for SockAddr {
 impl SockAddr {
     /// Constructs a `SockAddr` from its raw components.
     pub unsafe fn from_raw_parts(addr: *const sockaddr, len: socklen_t) -> SockAddr {
-        let mut storage = MaybeUninit::<sockaddr_storage>::uninit();
+        let mut storage = MaybeUninit::<sockaddr_storage>::zeroed();
         ptr::copy_nonoverlapping(
             addr as *const _ as *const u8,
-            &mut storage as *mut _ as *mut u8,
+            storage.as_mut_ptr() as *mut u8,
             len as usize,
         );
 
@@ -212,7 +212,7 @@ impl From<SocketAddrV4> for SockAddr {
             in_addr { S_un: s_un }
         };
 
-        let mut storage = MaybeUninit::<sockaddr_storage>::uninit();
+        let mut storage = MaybeUninit::<sockaddr_storage>::zeroed();
         let sockaddr_in = unsafe { &mut *(storage.as_mut_ptr() as *mut sockaddr_in) };
         *sockaddr_in = sockaddr_in {
             sin_family: AF_INET as sa_family_t,
@@ -255,7 +255,7 @@ impl From<SocketAddrV6> for SockAddr {
             u
         };
 
-        let mut storage = MaybeUninit::<sockaddr_storage>::uninit();
+        let mut storage = MaybeUninit::<sockaddr_storage>::zeroed();
         let sockaddr_in6 = unsafe { &mut *(storage.as_mut_ptr() as *mut sockaddr_in6) };
         *sockaddr_in6 = sockaddr_in6 {
             sin6_family: AF_INET6 as sa_family_t,

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -216,7 +216,16 @@ impl From<SocketAddrV4> for SockAddr {
             sin_family: AF_INET as sa_family_t,
             sin_port: addr.port().to_be(),
             sin_addr,
-            ..unsafe { mem::zeroed() }
+            sin_zero: [0; 8],
+            #[cfg(any(
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "ios",
+                target_os = "macos",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ))]
+            sin_len: 0,
         };
         SockAddr {
             storage: unsafe { storage.assume_init() },
@@ -255,7 +264,17 @@ impl From<SocketAddrV6> for SockAddr {
             sin6_scope_id: addr.scope_id(),
             #[cfg(windows)]
             u,
-            ..unsafe { mem::zeroed() }
+            #[cfg(any(
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "ios",
+                target_os = "macos",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ))]
+            sin6_len: 0,
+            #[cfg(any(target_os = "solaris", target_os = "illumos"))]
+            __sin6_src_id: 0,
         };
         SockAddr {
             storage: unsafe { storage.assume_init() },


### PR DESCRIPTION
Fixes #119 