### PR TITLE
Refactor part 5

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,8 +252,8 @@ impl RecvFlags {
     /// This flag is only used for datagram-based sockets,
     /// not for stream sockets.
     ///
-    /// On Unix this corresponds to the MSG_TRUNC flag.
-    /// On Windows this corresponds to the WSAEMSGSIZE error code.
+    /// On Unix this corresponds to the `MSG_TRUNC` flag.
+    /// On Windows this corresponds to the `WSAEMSGSIZE` error code.
     pub const fn is_truncated(self) -> bool {
         self.0 & sys::MSG_TRUNC != 0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ impl Domain {
     pub const IPV6: Domain = Domain(sys::AF_INET6);
 
     /// Returns the correct domain for `address`.
-    pub fn for_address(address: SocketAddr) -> Domain {
+    pub const fn for_address(address: SocketAddr) -> Domain {
         match address {
             SocketAddr::V4(_) => Domain::IPV4,
             SocketAddr::V6(_) => Domain::IPV6,
@@ -254,7 +254,7 @@ impl RecvFlags {
     ///
     /// On Unix this corresponds to the MSG_TRUNC flag.
     /// On Windows this corresponds to the WSAEMSGSIZE error code.
-    pub fn is_truncated(self) -> bool {
+    pub const fn is_truncated(self) -> bool {
         self.0 & sys::MSG_TRUNC != 0
     }
 }

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -39,6 +39,11 @@ impl SockAddr {
         }
     }
 
+    /// Constructs a `SockAddr` from its raw components.
+    pub(crate) const fn from_raw(storage: sockaddr_storage, len: socklen_t) -> SockAddr {
+        SockAddr { storage, len }
+    }
+
     /// Returns this address's family.
     pub fn family(&self) -> sa_family_t {
         self.storage.ss_family

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -59,6 +59,12 @@ impl SockAddr {
         &self.storage as *const _ as *const _
     }
 
+    /// Returns a raw pointer to the address storage.
+    #[cfg(unix)]
+    pub(crate) fn as_storage_ptr(&self) -> *const sockaddr_storage {
+        &self.storage
+    }
+
     /// Returns this address as a `SocketAddr` if it is in the `AF_INET` (IP v4)
     /// or `AF_INET6` (IP v6) family, otherwise returns `None`.
     pub fn as_std(&self) -> Option<SocketAddr> {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -345,19 +345,19 @@ impl Socket {
     /// Receives data from the socket. On success, returns the number of bytes
     /// read and the address from whence the data came.
     pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SockAddr)> {
-        self.inner().recv_from(buf, 0)
+        self.recv_from_with_flags(buf, 0)
     }
 
-    /// Identical to [`recv_from`] but allows for specification of arbitrary flags to the underlying
-    /// `recvfrom` call.
+    /// Identical to [`recv_from`] but allows for specification of arbitrary
+    /// flags to the underlying `recvfrom` call.
     ///
-    /// [`recv_from`]: #method.recv_from
+    /// [`recv_from`]: Socket::recv_from
     pub fn recv_from_with_flags(
         &self,
         buf: &mut [u8],
         flags: i32,
     ) -> io::Result<(usize, SockAddr)> {
-        self.inner().recv_from(buf, flags)
+        sys::recv_from(self.inner, buf, flags)
     }
 
     /// Identical to [`recv_from_with_flags`] but reads into a slice of buffers.

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -445,18 +445,17 @@ impl Socket {
     /// Sends data on the socket to the given address. On success, returns the
     /// number of bytes written.
     ///
-    /// This is typically used on UDP or datagram-oriented sockets. On success
-    /// returns the number of bytes that were sent.
+    /// This is typically used on UDP or datagram-oriented sockets.
     pub fn send_to(&self, buf: &[u8], addr: &SockAddr) -> io::Result<usize> {
-        self.inner().send_to(buf, 0, addr)
+        self.send_to_with_flags(buf, addr, 0)
     }
 
-    /// Identical to [`send_to`] but allows for specification of arbitrary flags to the underlying
-    /// `sendto` call.
+    /// Identical to [`send_to`] but allows for specification of arbitrary flags
+    /// to the underlying `sendto` call.
     ///
-    /// [`send_to`]: #method.send_to
+    /// [`send_to`]: Socket::send_to
     pub fn send_to_with_flags(&self, buf: &[u8], addr: &SockAddr, flags: i32) -> io::Result<usize> {
-        self.inner().send_to(buf, flags, addr)
+        sys::send_to(self.inner, buf, addr, flags)
     }
 
     /// Identical to [`send_with_flags`] but writes from a slice of buffers.

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -383,7 +383,7 @@ impl Socket {
     /// On success, returns the number of bytes peeked and the address from
     /// whence the data came.
     pub fn peek_from(&self, buf: &mut [u8]) -> io::Result<(usize, SockAddr)> {
-        self.inner().peek_from(buf)
+        self.recv_from_with_flags(buf, sys::MSG_PEEK)
     }
 
     /// Sends data on the socket to a connected peer.

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -458,20 +458,26 @@ impl Socket {
         sys::send_to(self.inner, buf, addr, flags)
     }
 
-    /// Identical to [`send_with_flags`] but writes from a slice of buffers.
-    ///
-    /// [`send_with_flags`]: #method.send_with_flags
+    /// Send data to a peer listening on `addr`. Returns the amount of bytes
+    /// written.
     #[cfg(not(target_os = "redox"))]
-    pub fn send_to_vectored(
+    pub fn send_to_vectored(&self, bufs: &[IoSlice<'_>], addr: &SockAddr) -> io::Result<usize> {
+        self.send_to_vectored_with_flags(bufs, addr, 0)
+    }
+
+    /// Identical to [`send_to_vectored`] but allows for specification of
+    /// arbitrary flags to the underlying `sendmsg`/`WSASendTo` call.
+    ///
+    /// [`send_to_vectored`]: Socket::send_to_vectored
+    #[cfg(not(target_os = "redox"))]
+    pub fn send_to_vectored_with_flags(
         &self,
         bufs: &[IoSlice<'_>],
         addr: &SockAddr,
         flags: i32,
     ) -> io::Result<usize> {
-        self.inner().send_to_vectored(bufs, flags, addr)
+        sys::send_to_vectored(self.inner, bufs, addr, flags)
     }
-
-    // ================================================
 
     /// Gets the value of the `IP_TTL` option for this socket.
     ///

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -307,19 +307,34 @@ impl Socket {
         sys::recv(self.inner, buf, flags)
     }
 
-    /// Identical to [`recv_with_flags`] but reads into a slice of buffers.
+    /// Receives data on the socket from the remote address to which it is
+    /// connected. Unlike [`recv`] that allows passing multiple buffers.
     ///
-    /// In addition to the number of bytes read, this function returns the flags for the received message.
-    /// See [`RecvFlags`] for more information about the flags.
+    /// The [`connect`] method will connect this socket to a remote address.
+    /// This method might fail if the socket is not connected.
     ///
-    /// [`recv_with_flags`]: #method.recv_with_flags
+    /// In addition to the number of bytes read, this function returns the flags
+    /// for the received message. See [`RecvFlags`] for more information about
+    /// the returned flags.
+    ///
+    /// [`recv`]: Socket::recv
+    /// [`connect`]: Socket::connect
     #[cfg(not(target_os = "redox"))]
-    pub fn recv_vectored(
+    pub fn recv_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<(usize, RecvFlags)> {
+        self.recv_vectored_with_flags(bufs, 0)
+    }
+
+    /// Identical to [`recv_vectored`] but allows for specification of arbitrary
+    /// flags to the underlying `recvmsg`/`WSARecv` call.
+    ///
+    /// [`recv_vectored`]: Socket::recv_vectored
+    #[cfg(not(target_os = "redox"))]
+    pub fn recv_vectored_with_flags(
         &self,
         bufs: &mut [IoSliceMut<'_>],
         flags: i32,
     ) -> io::Result<(usize, RecvFlags)> {
-        self.inner().recv_vectored(bufs, flags)
+        sys::recv_vectored(self.inner, bufs, flags)
     }
 
     /// Receives data on the socket from the remote adress to which it is

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -404,7 +404,7 @@ impl Socket {
     ///
     /// On success returns the number of bytes that were sent.
     pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
-        self.inner().send(buf, 0)
+        self.send_with_flags(buf, 0)
     }
 
     /// Identical to [`send`] but allows for specification of arbitrary flags to the underlying
@@ -412,7 +412,7 @@ impl Socket {
     ///
     /// [`send`]: #method.send
     pub fn send_with_flags(&self, buf: &[u8], flags: i32) -> io::Result<usize> {
-        self.inner().send(buf, flags)
+        sys::send(self.inner, buf, flags)
     }
 
     /// Identical to [`send_with_flags`] but writes from a slice of buffers.
@@ -432,7 +432,7 @@ impl Socket {
     /// [`out_of_band_inline`]: #method.out_of_band_inline
     #[cfg(all(feature = "all", not(target_os = "redox")))]
     pub fn send_out_of_band(&self, buf: &[u8]) -> io::Result<usize> {
-        self.inner().send(buf, sys::MSG_OOB)
+        self.send_with_flags(buf, sys::MSG_OOB)
     }
 
     /// Sends data on the socket to the given address. On success, returns the

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -899,13 +899,21 @@ impl Socket {
 
 impl Read for Socket {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner().read(buf)
+        self.recv(buf)
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        self.recv_vectored(bufs).map(|(n, _)| n)
     }
 }
 
 impl<'a> Read for &'a Socket {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner().read(buf)
+        self.recv(buf)
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        self.recv_vectored(bufs).map(|(n, _)| n)
     }
 }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -963,7 +963,11 @@ impl<'a> Write for &'a Socket {
 
 impl fmt::Debug for Socket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner().fmt(f)
+        f.debug_struct("Socket")
+            .field("raw", &self.inner)
+            .field("local_addr", &self.local_addr().ok())
+            .field("peer_addr", &self.peer_addr().ok())
+            .finish()
     }
 }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -415,12 +415,19 @@ impl Socket {
         sys::send(self.inner, buf, flags)
     }
 
-    /// Identical to [`send_with_flags`] but writes from a slice of buffers.
-    ///
-    /// [`send_with_flags`]: #method.send_with_flags
+    /// Send data to the connected peer. Returns the amount of bytes written.
     #[cfg(not(target_os = "redox"))]
-    pub fn send_vectored(&self, bufs: &[IoSlice<'_>], flags: i32) -> io::Result<usize> {
-        self.inner().send_vectored(bufs, flags)
+    pub fn send_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.send_vectored_with_flags(bufs, 0)
+    }
+
+    /// Identical to [`send_vectored`] but allows for specification of arbitrary
+    /// flags to the underlying `sendmsg`/`WSASend` call.
+    ///
+    /// [`send_vectored`]: Socket::send_vectored
+    #[cfg(not(target_os = "redox"))]
+    pub fn send_vectored_with_flags(&self, bufs: &[IoSlice<'_>], flags: i32) -> io::Result<usize> {
+        sys::send_vectored(self.inner, bufs, flags)
     }
 
     /// Sends out-of-band (OOB) data on the socket to connected peer
@@ -902,6 +909,7 @@ impl Read for Socket {
         self.recv(buf)
     }
 
+    #[cfg(not(target_os = "redox"))]
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.recv_vectored(bufs).map(|(n, _)| n)
     }
@@ -912,6 +920,7 @@ impl<'a> Read for &'a Socket {
         self.recv(buf)
     }
 
+    #[cfg(not(target_os = "redox"))]
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.recv_vectored(bufs).map(|(n, _)| n)
     }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -15,11 +15,6 @@ use std::net::{self, Ipv4Addr, Ipv6Addr, Shutdown};
 use std::os::unix::net::{UnixDatagram, UnixListener, UnixStream};
 use std::time::Duration;
 
-#[cfg(all(unix, feature = "all", not(target_os = "redox")))]
-use libc::MSG_OOB;
-#[cfg(all(windows, feature = "all"))]
-use winapi::um::winsock2::MSG_OOB;
-
 use crate::sys;
 #[cfg(not(target_os = "redox"))]
 use crate::RecvFlags;
@@ -296,7 +291,7 @@ impl Socket {
     /// [`out_of_band_inline`]: Socket::out_of_band_inline
     #[cfg(all(feature = "all", not(target_os = "redox")))]
     pub fn recv_out_of_band(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.recv_with_flags(buf, MSG_OOB)
+        self.recv_with_flags(buf, sys::MSG_OOB)
     }
 
     /// Identical to [`recv`] but allows for specification of arbitrary flags to
@@ -344,7 +339,7 @@ impl Socket {
     /// Successive calls return the same data. This is accomplished by passing
     /// `MSG_PEEK` as a flag to the underlying `recv` system call.
     pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner().peek(buf)
+        self.recv_with_flags(buf, sys::MSG_PEEK)
     }
 
     /// Receives data from the socket. On success, returns the number of bytes
@@ -426,7 +421,7 @@ impl Socket {
     /// [`out_of_band_inline`]: #method.out_of_band_inline
     #[cfg(all(feature = "all", not(target_os = "redox")))]
     pub fn send_out_of_band(&self, buf: &[u8]) -> io::Result<usize> {
-        self.inner().send(buf, MSG_OOB)
+        self.inner().send(buf, sys::MSG_OOB)
     }
 
     /// Sends data on the socket to the given address. On success, returns the

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -303,7 +303,7 @@ impl Socket {
     }
 
     /// Receives data on the socket from the remote address to which it is
-    /// connected. Unlike [`recv`] that allows passing multiple buffers.
+    /// connected. Unlike [`recv`] this allows passing multiple buffers.
     ///
     /// The [`connect`] method will connect this socket to a remote address.
     /// This method might fail if the socket is not connected.
@@ -360,19 +360,30 @@ impl Socket {
         sys::recv_from(self.inner, buf, flags)
     }
 
-    /// Identical to [`recv_from_with_flags`] but reads into a slice of buffers.
+    /// Receives data from the socket. Returns the amount of bytes read, the
+    /// [`RecvFlags`] and the remote address from the data is coming. Unlike
+    /// [`recv_from`] this allows passing multiple buffers.
     ///
-    /// In addition to the number of bytes read, this function returns the flags for the received message.
-    /// See [`RecvFlags`] for more information about the flags.
-    ///
-    /// [`recv_from_with_flags`]: #method.recv_from_with_flags
+    /// [`recv_from`]: Socket::recv_from
     #[cfg(not(target_os = "redox"))]
     pub fn recv_from_vectored(
         &self,
         bufs: &mut [IoSliceMut<'_>],
+    ) -> io::Result<(usize, RecvFlags, SockAddr)> {
+        self.recv_from_vectored_with_flags(bufs, 0)
+    }
+
+    /// Identical to [`recv_from_vectored`] but allows for specification of
+    /// arbitrary flags to the underlying `recvmsg`/`WSARecvFrom` call.
+    ///
+    /// [`recv_from_vectored`]: Socket::recv_from_vectored
+    #[cfg(not(target_os = "redox"))]
+    pub fn recv_from_vectored_with_flags(
+        &self,
+        bufs: &mut [IoSliceMut<'_>],
         flags: i32,
     ) -> io::Result<(usize, RecvFlags, SockAddr)> {
-        self.inner().recv_from_vectored(bufs, flags)
+        sys::recv_from_vectored(self.inner, bufs, flags)
     }
 
     /// Receives data from the socket, without removing it from the queue.

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -933,21 +933,31 @@ impl<'a> Read for &'a Socket {
 
 impl Write for Socket {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.inner().write(buf)
+        self.send(buf)
+    }
+
+    #[cfg(not(target_os = "redox"))]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.send_vectored(bufs)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.inner().flush()
+        Ok(())
     }
 }
 
 impl<'a> Write for &'a Socket {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.inner().write(buf)
+        self.send(buf)
+    }
+
+    #[cfg(not(target_os = "redox"))]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.send_vectored(bufs)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.inner().flush()
+        Ok(())
     }
 }
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -578,10 +578,6 @@ pub struct Socket {
 }
 
 impl Socket {
-    pub fn peek_from(&self, buf: &mut [u8]) -> io::Result<(usize, SockAddr)> {
-        recv_from(self.fd, buf, libc::MSG_PEEK)
-    }
-
     #[cfg(not(target_os = "redox"))]
     pub fn recv_from_vectored(
         &self,

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -7,9 +7,9 @@
 // except according to those terms.
 
 use std::cmp::min;
+use std::io::Write;
 #[cfg(not(target_os = "redox"))]
 use std::io::{IoSlice, IoSliceMut};
-use std::io::{Read, Write};
 use std::mem::{self, size_of, size_of_val, MaybeUninit};
 use std::net::Shutdown;
 use std::net::{self, Ipv4Addr, Ipv6Addr};
@@ -1024,23 +1024,6 @@ impl Socket {
 
     pub fn from_inner(fd: SysSocket) -> Socket {
         Socket { fd }
-    }
-}
-
-impl Read for Socket {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        <&Socket>::read(&mut &*self, buf)
-    }
-}
-
-impl<'a> Read for &'a Socket {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let n = syscall!(read(
-            self.fd,
-            buf.as_mut_ptr() as *mut c_void,
-            cmp::min(buf.len(), max_len()),
-        ))?;
-        Ok(n as usize)
     }
 }
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -221,7 +221,7 @@ impl RecvFlags {
     /// a record is terminated by sending a message with the end-of-record flag set.
     ///
     /// On Unix this corresponds to the MSG_EOR flag.
-    pub fn is_end_of_record(self) -> bool {
+    pub const fn is_end_of_record(self) -> bool {
         self.0 & libc::MSG_EOR != 0
     }
 
@@ -231,7 +231,7 @@ impl RecvFlags {
     /// mixed in with the normal data stream.
     ///
     /// On Unix this corresponds to the MSG_OOB flag.
-    pub fn is_out_of_band(self) -> bool {
+    pub const fn is_out_of_band(self) -> bool {
         self.0 & libc::MSG_OOB != 0
     }
 }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -7,7 +7,6 @@
 // except according to those terms.
 
 use std::cmp::min;
-use std::io::Write;
 #[cfg(not(target_os = "redox"))]
 use std::io::{IoSlice, IoSliceMut};
 use std::mem::{self, size_of, size_of_val, MaybeUninit};
@@ -1037,26 +1036,6 @@ impl Socket {
 
     pub fn from_inner(fd: SysSocket) -> Socket {
         Socket { fd }
-    }
-}
-
-impl Write for Socket {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        <&Socket>::write(&mut &*self, buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        <&Socket>::flush(&mut &*self)
-    }
-}
-
-impl<'a> Write for &'a Socket {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        send(self.fd, buf, 0)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
     }
 }
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -11,10 +11,11 @@ use std::cmp::min;
 use std::io::{IoSlice, IoSliceMut};
 use std::mem::{self, size_of, size_of_val, MaybeUninit};
 use std::net::Shutdown;
-use std::net::{self, Ipv4Addr, Ipv6Addr};
+use std::net::{Ipv4Addr, Ipv6Addr};
 #[cfg(feature = "all")]
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
+#[cfg(feature = "all")]
 use std::os::unix::net::{UnixDatagram, UnixListener, UnixStream};
 #[cfg(feature = "all")]
 use std::path::Path;
@@ -975,7 +976,10 @@ impl Socket {
         }
     }
 
-    #[cfg(not(any(target_os = "solaris", target_os = "illumos")))]
+    #[cfg(all(
+        feature = "all",
+        not(any(target_os = "solaris", target_os = "illumos"))
+    ))]
     pub fn reuse_port(&self) -> io::Result<bool> {
         unsafe {
             let raw: c_int = self.getsockopt(libc::SOL_SOCKET, libc::SO_REUSEPORT)?;
@@ -983,7 +987,10 @@ impl Socket {
         }
     }
 
-    #[cfg(not(any(target_os = "solaris", target_os = "illumos")))]
+    #[cfg(all(
+        feature = "all",
+        not(any(target_os = "solaris", target_os = "illumos"))
+    ))]
     pub fn set_reuse_port(&self, reuse: bool) -> io::Result<()> {
         unsafe { self.setsockopt(libc::SOL_SOCKET, libc::SO_REUSEPORT, reuse as c_int) }
     }
@@ -1032,10 +1039,6 @@ impl Socket {
 
     pub fn inner(self) -> SysSocket {
         self.fd
-    }
-
-    pub fn from_inner(fd: SysSocket) -> Socket {
-        Socket { fd }
     }
 }
 
@@ -1095,75 +1098,51 @@ impl FromRawFd for crate::Socket {
     }
 }
 
-impl From<Socket> for net::TcpStream {
-    fn from(socket: Socket) -> net::TcpStream {
-        unsafe { net::TcpStream::from_raw_fd(socket.into_raw_fd()) }
-    }
-}
-
-impl From<Socket> for net::TcpListener {
-    fn from(socket: Socket) -> net::TcpListener {
-        unsafe { net::TcpListener::from_raw_fd(socket.into_raw_fd()) }
-    }
-}
-
-impl From<Socket> for net::UdpSocket {
-    fn from(socket: Socket) -> net::UdpSocket {
-        unsafe { net::UdpSocket::from_raw_fd(socket.into_raw_fd()) }
-    }
-}
-
-impl From<Socket> for UnixStream {
-    fn from(socket: Socket) -> UnixStream {
+#[cfg(feature = "all")]
+impl From<crate::Socket> for UnixStream {
+    fn from(socket: crate::Socket) -> UnixStream {
         unsafe { UnixStream::from_raw_fd(socket.into_raw_fd()) }
     }
 }
 
-impl From<Socket> for UnixListener {
-    fn from(socket: Socket) -> UnixListener {
+#[cfg(feature = "all")]
+impl From<crate::Socket> for UnixListener {
+    fn from(socket: crate::Socket) -> UnixListener {
         unsafe { UnixListener::from_raw_fd(socket.into_raw_fd()) }
     }
 }
 
-impl From<Socket> for UnixDatagram {
-    fn from(socket: Socket) -> UnixDatagram {
+#[cfg(feature = "all")]
+impl From<crate::Socket> for UnixDatagram {
+    fn from(socket: crate::Socket) -> UnixDatagram {
         unsafe { UnixDatagram::from_raw_fd(socket.into_raw_fd()) }
     }
 }
 
-impl From<net::TcpStream> for Socket {
-    fn from(socket: net::TcpStream) -> Socket {
-        unsafe { Socket::from_raw_fd(socket.into_raw_fd()) }
+#[cfg(feature = "all")]
+impl From<UnixStream> for crate::Socket {
+    fn from(socket: UnixStream) -> crate::Socket {
+        crate::Socket {
+            inner: socket.into_raw_fd(),
+        }
     }
 }
 
-impl From<net::TcpListener> for Socket {
-    fn from(socket: net::TcpListener) -> Socket {
-        unsafe { Socket::from_raw_fd(socket.into_raw_fd()) }
+#[cfg(feature = "all")]
+impl From<UnixListener> for crate::Socket {
+    fn from(socket: UnixListener) -> crate::Socket {
+        crate::Socket {
+            inner: socket.into_raw_fd(),
+        }
     }
 }
 
-impl From<net::UdpSocket> for Socket {
-    fn from(socket: net::UdpSocket) -> Socket {
-        unsafe { Socket::from_raw_fd(socket.into_raw_fd()) }
-    }
-}
-
-impl From<UnixStream> for Socket {
-    fn from(socket: UnixStream) -> Socket {
-        unsafe { Socket::from_raw_fd(socket.into_raw_fd()) }
-    }
-}
-
-impl From<UnixListener> for Socket {
-    fn from(socket: UnixListener) -> Socket {
-        unsafe { Socket::from_raw_fd(socket.into_raw_fd()) }
-    }
-}
-
-impl From<UnixDatagram> for Socket {
-    fn from(socket: UnixDatagram) -> Socket {
-        unsafe { Socket::from_raw_fd(socket.into_raw_fd()) }
+#[cfg(feature = "all")]
+impl From<UnixDatagram> for crate::Socket {
+    fn from(socket: UnixDatagram) -> crate::Socket {
+        crate::Socket {
+            inner: socket.into_raw_fd(),
+        }
     }
 }
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -465,6 +465,7 @@ pub(crate) fn recv_from_vectored(
 }
 
 /// Returns the (bytes received, sending address len, `RecvFlags`).
+#[cfg(not(target_os = "redox"))]
 fn recvmsg(
     fd: SysSocket,
     msg_name: *mut sockaddr_storage,
@@ -536,6 +537,7 @@ pub(crate) fn send_to_vectored(
 }
 
 /// Returns the (bytes received, sending address len, `RecvFlags`).
+#[cfg(not(target_os = "redox"))]
 fn sendmsg(
     fd: SysSocket,
     msg_name: *const sockaddr_storage,

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -9,7 +9,7 @@
 use std::cmp::{self, min};
 use std::fmt;
 use std::io;
-use std::io::{IoSlice, IoSliceMut, Read, Write};
+use std::io::{IoSlice, IoSliceMut, Write};
 use std::mem::{self, size_of, size_of_val, MaybeUninit};
 use std::net::Shutdown;
 use std::net::{self, Ipv4Addr, Ipv6Addr};
@@ -881,18 +881,6 @@ impl Socket {
 
     pub fn from_inner(socket: SysSocket) -> Socket {
         Socket { socket }
-    }
-}
-
-impl Read for Socket {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        <&Socket>::read(&mut &*self, buf)
-    }
-}
-
-impl<'a> Read for &'a Socket {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        recv(self.socket, buf, 0)
     }
 }
 

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -842,6 +842,7 @@ impl Socket {
         }
     }
 
+    #[cfg(feature = "all")]
     pub fn out_of_band_inline(&self) -> io::Result<bool> {
         unsafe {
             let raw: c_int = self.getsockopt(SOL_SOCKET, SO_OOBINLINE)?;
@@ -849,6 +850,7 @@ impl Socket {
         }
     }
 
+    #[cfg(feature = "all")]
     pub fn set_out_of_band_inline(&self, oob_inline: bool) -> io::Result<()> {
         unsafe { self.setsockopt(SOL_SOCKET, SO_OOBINLINE, oob_inline as c_int) }
     }
@@ -885,10 +887,6 @@ impl Socket {
 
     pub fn inner(self) -> SysSocket {
         self.socket
-    }
-
-    pub fn from_inner(socket: SysSocket) -> Socket {
-        Socket { socket }
     }
 }
 
@@ -947,42 +945,6 @@ impl FromRawSocket for crate::Socket {
         crate::Socket {
             inner: Socket::from_raw_socket(socket).inner(),
         }
-    }
-}
-
-impl From<Socket> for net::TcpStream {
-    fn from(socket: Socket) -> net::TcpStream {
-        unsafe { net::TcpStream::from_raw_socket(socket.into_raw_socket()) }
-    }
-}
-
-impl From<Socket> for net::TcpListener {
-    fn from(socket: Socket) -> net::TcpListener {
-        unsafe { net::TcpListener::from_raw_socket(socket.into_raw_socket()) }
-    }
-}
-
-impl From<Socket> for net::UdpSocket {
-    fn from(socket: Socket) -> net::UdpSocket {
-        unsafe { net::UdpSocket::from_raw_socket(socket.into_raw_socket()) }
-    }
-}
-
-impl From<net::TcpStream> for Socket {
-    fn from(socket: net::TcpStream) -> Socket {
-        unsafe { Socket::from_raw_socket(socket.into_raw_socket()) }
-    }
-}
-
-impl From<net::TcpListener> for Socket {
-    fn from(socket: net::TcpListener) -> Socket {
-        unsafe { Socket::from_raw_socket(socket.into_raw_socket()) }
-    }
-}
-
-impl From<net::UdpSocket> for Socket {
-    fn from(socket: net::UdpSocket) -> Socket {
-        unsafe { Socket::from_raw_socket(socket.into_raw_socket()) }
     }
 }
 
@@ -1124,6 +1086,7 @@ fn test_ipv6() {
 }
 
 #[test]
+#[cfg(feature = "all")]
 fn test_out_of_band_inline() {
     let tcp = Socket {
         socket: socket(AF_INET, SOCK_STREAM, 0).unwrap(),

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -414,10 +414,6 @@ pub struct Socket {
 }
 
 impl Socket {
-    pub fn peek_from(&self, buf: &mut [u8]) -> io::Result<(usize, SockAddr)> {
-        recv_from(self.socket, buf, MSG_PEEK)
-    }
-
     pub fn recv_from_vectored(
         &self,
         bufs: &mut [IoSliceMut<'_>],

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use std::cmp::min;
-use std::io::{self, IoSlice, IoSliceMut, Write};
+use std::io::{self, IoSlice, IoSliceMut};
 use std::mem::{self, size_of, size_of_val, MaybeUninit};
 use std::net::{self, Ipv4Addr, Ipv6Addr, Shutdown};
 use std::os::windows::prelude::*;
@@ -889,26 +889,6 @@ impl Socket {
 
     pub fn from_inner(socket: SysSocket) -> Socket {
         Socket { socket }
-    }
-}
-
-impl Write for Socket {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        <&Socket>::write(&mut &*self, buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        <&Socket>::flush(&mut &*self)
-    }
-}
-
-impl<'a> Write for &'a Socket {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        send(self.socket, buf, 0)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -215,7 +215,6 @@ fn send_from_recv_to_vectored() {
                 IoSlice::new(b"menswear"),
             ],
             &addr_b,
-            0,
         )
         .unwrap();
     assert_eq!(sent, 18);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -177,17 +177,14 @@ fn send_recv_vectored() {
     let mut ow = [0u8; 2];
 
     let (received, flags) = socket_b
-        .recv_vectored(
-            &mut [
-                IoSliceMut::new(&mut the),
-                IoSliceMut::new(&mut wee),
-                IoSliceMut::new(&mut knight),
-                IoSliceMut::new(&mut would),
-                IoSliceMut::new(&mut yell),
-                IoSliceMut::new(&mut ow),
-            ],
-            0,
-        )
+        .recv_vectored(&mut [
+            IoSliceMut::new(&mut the),
+            IoSliceMut::new(&mut wee),
+            IoSliceMut::new(&mut knight),
+            IoSliceMut::new(&mut would),
+            IoSliceMut::new(&mut yell),
+            IoSliceMut::new(&mut ow),
+        ])
         .unwrap();
     assert_eq!(received, 23);
     #[cfg(all(unix, not(target_os = "redox")))]
@@ -270,7 +267,7 @@ fn recv_vectored_truncated() {
     let mut buffer = [0u8; 24];
 
     let (received, flags) = socket_b
-        .recv_vectored(&mut [IoSliceMut::new(&mut buffer)], 0)
+        .recv_vectored(&mut [IoSliceMut::new(&mut buffer)])
         .unwrap();
     assert_eq!(received, 24);
     assert_eq!(flags.is_truncated(), true);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -228,15 +228,12 @@ fn send_from_recv_to_vectored() {
     let mut men = [0u8; 3];
     let mut swear = [0u8; 5];
     let (received, flags, addr) = socket_b
-        .recv_from_vectored(
-            &mut [
-                IoSliceMut::new(&mut surgeon),
-                IoSliceMut::new(&mut has),
-                IoSliceMut::new(&mut men),
-                IoSliceMut::new(&mut swear),
-            ],
-            0,
-        )
+        .recv_from_vectored(&mut [
+            IoSliceMut::new(&mut surgeon),
+            IoSliceMut::new(&mut has),
+            IoSliceMut::new(&mut men),
+            IoSliceMut::new(&mut swear),
+        ])
         .unwrap();
 
     assert_eq!(received, 18);
@@ -291,7 +288,7 @@ fn recv_from_vectored_truncated() {
     let mut buffer = [0u8; 24];
 
     let (received, flags, addr) = socket_b
-        .recv_from_vectored(&mut [IoSliceMut::new(&mut buffer)], 0)
+        .recv_from_vectored(&mut [IoSliceMut::new(&mut buffer)])
         .unwrap();
     assert_eq!(received, 24);
     assert_eq!(flags.is_truncated(), true);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -157,15 +157,12 @@ fn send_recv_vectored() {
     let (socket_a, socket_b) = udp_pair_connected();
 
     let sent = socket_a
-        .send_vectored(
-            &[
-                IoSlice::new(b"the"),
-                IoSlice::new(b"weeknight"),
-                IoSlice::new(b"would"),
-                IoSlice::new(b"yellow"),
-            ],
-            0,
-        )
+        .send_vectored(&[
+            IoSlice::new(b"the"),
+            IoSlice::new(b"weeknight"),
+            IoSlice::new(b"would"),
+            IoSlice::new(b"yellow"),
+        ])
         .unwrap();
     assert_eq!(sent, 23);
 


### PR DESCRIPTION
Refactors the `recv` and `send` and related functions, including the `io::Read` and `io::Write` implementations.

Also changes the `Socket::new`, `Socket::pair` and `Socket::accept` functions to set close-on-exec flag on Unix, on Apple platforms `SOCK_NOSIGPIPE` and on Windows the socket is made non-inheritable. New `Socket::new_raw`, `Socket::pair_raw` and `Socket::accept_raw` functions are added which do not set the above flags. This work as done by @de-vri-es in #117.
