### PR TITLE
Fix compilation on Haiku

### DIFF
--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -131,10 +131,11 @@ impl From<SocketAddrV4> for SockAddr {
             sin_family: AF_INET as sa_family_t,
             sin_port: addr.port().to_be(),
             sin_addr: crate::sys::to_in_addr(&addr.ip()),
-            sin_zero: [0; 8],
+            sin_zero: Default::default(),
             #[cfg(any(
                 target_os = "dragonfly",
                 target_os = "freebsd",
+                target_os = "haiku",
                 target_os = "ios",
                 target_os = "macos",
                 target_os = "netbsd",
@@ -173,6 +174,7 @@ impl From<SocketAddrV6> for SockAddr {
             #[cfg(any(
                 target_os = "dragonfly",
                 target_os = "freebsd",
+                target_os = "haiku",
                 target_os = "ios",
                 target_os = "macos",
                 target_os = "netbsd",


### PR DESCRIPTION
`sin_len` and `sin6_len` are apparently required on all BSD-like systems, from which Haiku probably inherits its network stack.

`sin_zero` has been changed from 8 bytes to 24 bytes in hrev9079 in order to stay compatible with BeOS.

This was apparently broken in #120.