### PR TITLE
add missing IovLen definition for illumos

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -117,6 +117,8 @@ type IovLen = usize;
     target_os = "macos",
     target_os = "netbsd",
     target_os = "openbsd",
+    target_os = "solaris",
+    target_os = "illumos",
 ))]
 type IovLen = c_int;
 


### PR DESCRIPTION
When vectored I/O was added (see pull request #107) a type definition was not
added for the "msg_iovlen" member on illumos (or Solaris) systems.  I have
added one that matches the illumos socket.h definition:

https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/sys/socket.h#L363

With this change, the tests appear to pass correctly on an illumos system:

```
$ cargo test --features all
    Finished test [unoptimized + debuginfo] target(s) in 0.02s
     Running target/debug/deps/socket2-3e7879ec551f2818

running 21 tests
test sockaddr::tests::conversion_v4 ... ok
test sockaddr::tests::conversion_v6 ... ok
test socket::test::nodelay ... ok
test socket::test::out_of_band_inline ... ok
test socket::test::keepalive ... ok
test socket::test::pair ... ok
test sys::test_ip ... ok
test socket::test::tcp ... ok
test sys::test_out_of_band_inline ... ok
test tests::domain_fmt_debug ... ok
test tests::domain_for_address ... ok
test tests::protocol_fmt_debug ... ok
test tests::recv_from_vectored_truncated ... ok
test tests::recv_vectored_truncated ... ok
test tests::send_from_recv_to_vectored ... ok
test tests::socket_address_ipv4 ... ok
test tests::send_recv_vectored ... ok
test tests::socket_address_ipv6 ... ok
test tests::socket_address_unix ... ok
test socket::test::unix ... ok
test tests::type_fmt_debug ... ok

test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/socket-ac6b7a5ed91229a9

running 4 tests
test no_default_flags ... ok
test default_flags ... ok
test set_cloexec ... ok
test set_nonblocking ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests socket2

running 2 tests
test src/socket.rs - socket::Socket (line 50) ... ok
test src/lib.rs - (line 36) ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```