### PR TITLE
Enable some constants that are actually available on redox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ features = ["all"]
 version = "0.3.3"
 features = ["handleapi", "ws2def", "ws2ipdef", "ws2tcpip", "minwindef"]
 
-[target."cfg(any(unix, target_os = \"redox\"))".dependencies]
+[target."cfg(unix)".dependencies]
 cfg-if = "1.0.0"
-libc = "0.2.66"
+libc = "0.2.81"
 
 [target."cfg(target_os = \"redox\")".dependencies]
 redox_syscall = "0.1.38"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ impl Type {
     pub const DGRAM: Type = Type(sys::SOCK_DGRAM);
 
     /// Type corresponding to `SOCK_SEQPACKET`.
-    #[cfg(all(feature = "all", not(target_os = "redox")))]
+    #[cfg(feature = "all")]
     pub const SEQPACKET: Type = Type(sys::SOCK_SEQPACKET);
 
     /// Type corresponding to `SOCK_RAW`.

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -308,7 +308,7 @@ impl Socket {
     ///
     /// [`recv`]: Socket::recv
     /// [`out_of_band_inline`]: Socket::out_of_band_inline
-    #[cfg(all(feature = "all", not(target_os = "redox")))]
+    #[cfg(feature = "all")]
     pub fn recv_out_of_band(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.recv_with_flags(buf, sys::MSG_OOB)
     }
@@ -456,7 +456,7 @@ impl Socket {
     ///
     /// [`send`]: #method.send
     /// [`out_of_band_inline`]: #method.out_of_band_inline
-    #[cfg(all(feature = "all", not(target_os = "redox")))]
+    #[cfg(feature = "all")]
     pub fn send_out_of_band(&self, buf: &[u8]) -> io::Result<usize> {
         self.send_with_flags(buf, sys::MSG_OOB)
     }
@@ -914,7 +914,7 @@ impl Socket {
     /// For more information about this option, see [`set_out_of_band_inline`][link].
     ///
     /// [link]: #method.set_out_of_band_inline
-    #[cfg(all(feature = "all", not(target_os = "redox")))]
+    #[cfg(feature = "all")]
     pub fn out_of_band_inline(&self) -> io::Result<bool> {
         self.inner().out_of_band_inline()
     }
@@ -1228,7 +1228,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(feature = "all", not(target_os = "redox")))]
+    #[cfg(feature = "all")]
     fn out_of_band_inline() {
         let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
 


### PR DESCRIPTION
`libc` recently added more constants for redox, so some of the cfgs can be removed.